### PR TITLE
Proposal: use absolute Python PATH

### DIFF
--- a/swallow.py
+++ b/swallow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 import argparse
 import i3ipc


### PR DESCRIPTION
Problem: if you use conda, you need to install i3ipc in every environment, otherwise swallow fails to run.  Answer - use absolute PATH to Python3, which is probably user installs i3-swallow.